### PR TITLE
Remove unused tables from `REFRESH TABLE`

### DIFF
--- a/notebooks/search/full_text_and_vector_search.ipynb
+++ b/notebooks/search/full_text_and_vector_search.ipynb
@@ -140,7 +140,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = connection.execute(sa.text(\"REFRESH TABLE community_areas, three_eleven_calls, libraries\"))\n",
+    "_ = connection.execute(sa.text(\"REFRESH TABLE community_areas\"))\n",
     "_ = connection.execute(sa.text(\"ANALYZE\"))"
    ]
   },


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Neither the table `three_eleven_calls` nor `libraries` is created and/or used in this notebook. `ANALYZE` will throw an error about non-existent tables when running this notebook standalone. Refreshing those tables is already handled in the multi-model data notebook.