### PR TITLE
Use `pip -U` when installing packages

### DIFF
--- a/notebooks/multi_model_data/multi_model_data.ipynb
+++ b/notebooks/multi_model_data/multi_model_data.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install ipyleaflet sqlalchemy-cratedb pandas"
+    "! pip install -U ipyleaflet sqlalchemy-cratedb pandas"
    ]
   },
   {

--- a/notebooks/search/full_text_and_vector_search.ipynb
+++ b/notebooks/search/full_text_and_vector_search.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install sqlalchemy-cratedb pandas"
+    "! pip install -U sqlalchemy-cratedb pandas"
    ]
   },
   {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Use `pip -U` to update packages in case a previous (older) version is already installed

## Checklist

 - [X] Link to issue this PR refers to (if applicable): Fixes #???
