### PR TITLE
Fixed typo in one of the Jupyter notebooks.

### DIFF
--- a/notebooks/search/full_text_and_vector_search.ipynb
+++ b/notebooks/search/full_text_and_vector_search.ipynb
@@ -602,7 +602,7 @@
    "source": [
     "Take a moment to look at the results here and see how they differ to those from the previous query that searched for \"railroad\" or \"tracks\". \n",
     "\n",
-    "Let's search for communities whose description matches both \"railword\" and \"historic\":"
+    "Let's search for communities whose description matches both \"railroad\" and \"historic\":"
    ]
   },
   {


### PR DESCRIPTION
Fixed typo "railword" -> "railroad".  Closes #14 - I've done this as we didn't get a CLA from the original author there.
