### PR TITLE
CI: Update to explicitly use llvmlite>=0.40

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cratedb-toolkit[datasets]==0.0.29
 ipyleaflet<0.20
 kaleido<0.3
+llvmlite>=0.40
 pandas<2.1
 plotly<5.25
 pycaret<3.4


### PR DESCRIPTION
## About
Aiming to fix a hiccup with [llvmlite](https://pypi.org/project/llvmlite/) when updating pandas to a more recent version.

- https://github.com/crate/academy-fundamentals-course/pull/27#issuecomment-2457113273

## Problem
When updating pandas through a Dependabot PR, the installation process on CI/GHA suddenly selects a very old version of `llvmlite`, which fails to install successfully in both Python 3.10 and 3.12 environments.
```python
Failed to download and build `llvmlite==0.36.0`
RuntimeError: Cannot install on Python version {3.10.15,3.12.7}; only versions
>=3.6,<3.10 are supported.
```

Could it be related to the package resolution of the `uv` installer? Is something wrong with published project metadata of the `llvmlite` package?

/cc @konstin, @zanieb, @charliermarsh
