### PR TITLE
Revert "Update kaleido requirement from <0.3 to <0.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cratedb-toolkit[datasets]==0.0.29
 ipyleaflet<0.20
-kaleido<0.5
+kaleido<0.3
 pandas<2.1
 plotly<5.25
 pycaret<3.4


### PR DESCRIPTION
This reverts commit db71bd00c5388a9d659886770378be41c5ffa77f.

Was the update to kaleido in GH-29 responsible for the CI failing now, e.g. at [run #12186281891](https://github.com/crate/academy-fundamentals-course/actions/runs/12186281891/job/33995178607)?

Because this PR succeeds CI, let's merge it to be safe, and investigate about kaleido update later.