### PR TITLE
Dependencies: Explicitly use PyCaret >= 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ kaleido<0.3
 llvmlite>=0.40
 pandas<2.1
 plotly<5.25
-pycaret<3.4
+pycaret>=3,<3.4
 pydantic<3
 refinitiv-data<1.7
 sqlalchemy<2.1


### PR DESCRIPTION
## Problem
Looks like the package installer selects an old version of PyCaret. This patch bumps it to use PyCaret >=3.

-- https://github.com/crate/academy-fundamentals-course/actions/runs/12187513828/job/33998467147?pr=27#step:6:107