### PR TITLE
CI and Sandbox: Temporarily remove use of `uv`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,13 +78,10 @@ jobs:
             requirements.txt
             requirements-dev.txt
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-
       - name: Set up project
         run: |
           # Install runtime and development requirements.
-          uv pip install --system --upgrade -r requirements.txt -r requirements-dev.txt
+          pip install --upgrade -r requirements.txt -r requirements-dev.txt
 
       - name: Run linter and software tests
         run: |

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -7,15 +7,11 @@ docker run --rm -it --name=cratedb \
   --env=CRATE_HEAP_SIZE=2g crate:latest -Cdiscovery.type=single-node
 ```
 
-Install Python package and project manager [uv].
-```shell
-{apt,brew,pip,zypper} install uv
-```
-
 Set up Python environment and install requirements.
 ```shell
-uv venv --python=python3.12
-uv pip install --upgrade -r requirements.txt -r requirements-dev.txt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade -r requirements.txt -r requirements-dev.txt
 ```
 
 Invoke linters and software tests.


### PR DESCRIPTION
`uv` provided some hiccups in dependency resolutions, so we are trying without, in order to check if this improves the situation, or if it's unrelated.

- GH-32
- GH-35

Most prominently, the update to a higher version of pandas still does not succeed after many cycles to make it so.

- GH-27