### PR TITLE
Timeseries Notebook: When installing packages, don't `--upgrade`

### DIFF
--- a/notebooks/timeseries/timeseries_data.ipynb
+++ b/notebooks/timeseries/timeseries_data.ipynb
@@ -38,7 +38,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "! pip install -U -r https://github.com/crate/academy-fundamentals-course/raw/refs/heads/main/requirements.txt"
+   "source": "! pip install --verbose -r https://github.com/crate/academy-fundamentals-course/raw/refs/heads/main/requirements.txt"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
... and also use `--verbose` temporarily to be able to see where time is spent.
