### PR TITLE
Enable caching for uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,10 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements*.txt"
+          cache-suffix: ${{ matrix.python-version }}
 
       - name: Set up project
         run: |


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Enables storing the uv cache in GitHub Action's cache. This reduces the CI setup time from >8m to <2m. An example run can be seen [here](https://github.com/zanieb/academy-fundamentals-course/actions/runs/12189156092/job/34003715003). 

Most of the time was spent building pandas from source, ref https://github.com/crate/academy-fundamentals-course/pull/36 — uv's cache will include the built wheel.

edit: This appears to no longer be slow on `main`, perhaps not worth it?

