### PR TITLE
Clean up `requirements.txt`

### DIFF
--- a/notebooks/timeseries/timeseries_data.ipynb
+++ b/notebooks/timeseries/timeseries_data.ipynb
@@ -28,9 +28,7 @@
     "\n",
     "## Install Dependencies\n",
     "\n",
-    "First, install the required dependencies by executing the `pip install` command below.  Make sure to restart the notebook runtime environment once this command has completed.\n",
-    "\n",
-    "**Google Colab Note:** Google colab currently uses pandas 1.5.3.  While installing dependencies, expect to see compatibility errors.  You can safely ignore these."
+    "First, install the required dependencies by executing the `pip install` command below.  Make sure to restart the notebook runtime environment once this command has completed."
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,5 @@
-cratedb-toolkit[datasets]==0.0.31
-ipyleaflet<0.20
-kaleido<0.3
-llvmlite>=0.40
-pandas<2.3
 plotly<5.25
-pycaret>=3,<3.4
-pydantic<3
-refinitiv-data<1.7
+# not imported explicitly, but used by plotly to render PNGs
+kaleido<0.3
 sqlalchemy<2.1
 sqlalchemy-cratedb==0.41.0


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

After cleaning up `requirements.txt`, there are no more package conflicts. It is only used in the time-series notebook.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
