### PR TITLE
Update full_text_and_vector_search.ipynb

### DIFF
--- a/notebooks/search/full_text_and_vector_search.ipynb
+++ b/notebooks/search/full_text_and_vector_search.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U sqlalchemy-cratedb pandas"
+    "! pip install -U sqlalchemy-cratedb pandas==2.2.2"
    ]
   },
   {


### PR DESCRIPTION
Explicitly added pandas==2.2.2 to prevent:
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. google-colab 1.0.0 requires pandas==2.2.2, but you have pandas 2.2.3 which is incompatible.

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
