### PR TITLE
CI: Disable redundant caching of Python packages (pip vs. uv)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,17 +74,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "requirements*.txt"
+          cache-dependency-glob: |
+            requirements*.txt
           cache-suffix: ${{ matrix.python-version }}
 
       - name: Set up project


### PR DESCRIPTION
Enabling package caching for both vanilla pip and uv might be unfortunate, as possibly observed elsewhere.