### PR TITLE
Dependencies: Explicitly include direct dependencies. Here: `pandas` and `numpy`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-plotly<6.1
-# not imported explicitly, but used by plotly to render PNGs
+# Kaleido is not imported directly, but it is needed for Plotly to render PNGs.
 kaleido<0.3
-sqlalchemy<2.1
+pandas<2.1
+plotly<6.1
 sqlalchemy-cratedb==0.41.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Kaleido is not imported directly, but it is needed for Plotly to render PNGs.
 kaleido<0.3
+numpy<2
 pandas<2.1
 plotly<6.1
 sqlalchemy-cratedb==0.41.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Kaleido is not imported directly, but it is needed for Plotly to render PNGs.
 kaleido<0.3
 numpy<2
-pandas<2.1
+pandas<2.3
 plotly<6.1
 sqlalchemy-cratedb==0.41.0


### PR DESCRIPTION
## Problem

Nightly tests started failing.

```python
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[6], line 1
----> 1 import pandas as pd
      2 import numpy as np
      4 query = """
      5 SELECT ts, station, airtemp, humidity, intervalrain as rain FROM weather_data 
      6 WHERE station in ('Foster', 'Oak Street') ORDER BY ts DESC LIMIT 10
      7 """

ModuleNotFoundError: No module named 'pandas'
```

-- https://github.com/crate/academy-fundamentals-course/actions/runs/13558090787/job/37955858600#step:7:320
